### PR TITLE
Proposal: Change 'tar_options' to 'options' in golang|extract-archive

### DIFF
--- a/golang/init.sls
+++ b/golang/init.sls
@@ -45,7 +45,7 @@ golang|extract-archive:
     - archive_format: tar
     - user: root
     - group: root
-    - tar_options: v
+    - options: v
     - watch:
         - file: golang|cache-archive
     # golang|cache-archive already applies these predicates and the watch


### PR DESCRIPTION
This is because salt prints the following warning:

```
"Warnings: The 'tar_options' argument has been deprecated, please use 'options' instead."
```

I'm using salt 2016.11.2 Carbon.